### PR TITLE
Fix forum replies display and improve category navigation

### DIFF
--- a/CommunityFinder/Services/ForumService.cs
+++ b/CommunityFinder/Services/ForumService.cs
@@ -1,6 +1,8 @@
 using CommunityFinder.Models;
 using Supabase;
 using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace CommunityFinder.Services
 {
@@ -25,6 +27,19 @@ namespace CommunityFinder.Services
             var userId = Guid.Parse(_client.Auth.CurrentSession.User.Id);
             var profile = await _client.From<Profiles>().Where(x => x.id == userId).Single();
             return profile?.username ?? "Anonymous";
+        }
+
+        private async Task<string> GetUsernameByIdAsync(Guid userId)
+        {
+            try
+            {
+                var profile = await _client.From<Profiles>().Where(x => x.id == userId).Single();
+                return profile?.username ?? "Anonymous";
+            }
+            catch
+            {
+                return "Unknown";
+            }
         }
 
         // ========== Category Operations ==========
@@ -192,7 +207,7 @@ namespace CommunityFinder.Services
         public async Task<List<ForumReply>> GetRepliesToUserPostsAsync()
         {
             var userId = Guid.Parse(_client.Auth.CurrentSession.User.Id);
-            
+
             // Get all user's posts
             var userPosts = await GetUserPostsAsync();
             var postIds = userPosts.Select(p => p.Id).ToList();
@@ -201,19 +216,35 @@ namespace CommunityFinder.Services
 
             // Get all replies to those posts, excluding replies from the user themselves
             var allReplies = new List<ForumReply>();
+            var usernameCache = new Dictionary<Guid, string>();
             foreach (var postId in postIds)
             {
                 var replies = await _client.From<ForumReply>()
                     .Where(x => x.PostId == postId)
                     .Order(x => x.CreatedAt, Supabase.Postgrest.Constants.Ordering.Descending)
                     .Get();
-                
+
                 // Filter out user's own replies in memory
                 var filteredReplies = replies.Models.Where(r => r.UserId != userId).ToList();
-                allReplies.AddRange(filteredReplies);
+
+                foreach (var reply in filteredReplies)
+                {
+                    if (string.IsNullOrWhiteSpace(reply.Username))
+                    {
+                        if (!usernameCache.TryGetValue(reply.UserId, out var cachedUsername))
+                        {
+                            cachedUsername = await GetUsernameByIdAsync(reply.UserId);
+                            usernameCache[reply.UserId] = cachedUsername;
+                        }
+
+                        reply.Username = cachedUsername;
+                    }
+
+                    allReplies.Add(reply);
+                }
             }
 
-            return allReplies;
+            return allReplies.OrderByDescending(r => r.CreatedAt).ToList();
         }
 
         public async Task<ForumReply> CreateReplyAsync(Guid postId, string content, 

--- a/CommunityFinder/Views/ForumCategoriesPage.xaml
+++ b/CommunityFinder/Views/ForumCategoriesPage.xaml
@@ -14,17 +14,41 @@
                Margin="16,16,16,0"
                CornerRadius="14"
                HasShadow="True">
-            <Entry Placeholder="Search posts by topic..."
-                   x:Name="SearchEntry"
-                   TextChanged="OnSearchTextChanged"
-                   BackgroundColor="White"
-                   FontSize="16" />
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <Entry Placeholder="Search posts by topic..."
+                       x:Name="SearchEntry"
+                       BackgroundColor="White"
+                       FontSize="16"
+                       Completed="OnSearchCompleted" />
+
+                <Button Text="Search"
+                        Grid.Column="1"
+                        BackgroundColor="#4A90E2"
+                        TextColor="White"
+                        Clicked="OnSearchButtonClicked"
+                        CornerRadius="10"
+                        Padding="12,10" />
+            </Grid>
         </Frame>
 
 
         <!-- 分类网格 -->
         <ScrollView Grid.Row="1">
             <VerticalStackLayout Padding="12" Spacing="14">
+
+                <!-- 推荐最多浏览的分类 -->
+                <VerticalStackLayout x:Name="TopVisitedSection"
+                                     Spacing="8"
+                                     IsVisible="False"
+                                     Padding="4,0">
+                    <Label Text="Recommended for you"
+                           FontAttributes="Bold"
+                           FontSize="16"
+                           TextColor="#333" />
+                    <HorizontalStackLayout x:Name="TopVisitedLayout"
+                                           Spacing="10">
+                    </HorizontalStackLayout>
+                </VerticalStackLayout>
 
                 <CollectionView x:Name="CategoriesCollection"
                                 ItemsLayout="VerticalGrid,2"

--- a/CommunityFinder/Views/ForumCategoriesPage.xaml.cs
+++ b/CommunityFinder/Views/ForumCategoriesPage.xaml.cs
@@ -1,7 +1,9 @@
-﻿using CommunityFinder.Models;
+using CommunityFinder.Models;
 using CommunityFinder.Services;
+using Microsoft.Maui.Storage;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
-
+using System.Text.Json;
 
 namespace CommunityFinder.Views
 {
@@ -12,6 +14,7 @@ namespace CommunityFinder.Views
 
         private ObservableCollection<ForumCategoryDisplay> _categories;
         private List<ForumCategory> _allCategories;
+        private const string CategoryViewKey = "ForumCategoryViews";
 
         public ForumCategoriesPage(ForumService forumService, AuthService authService)
         {
@@ -71,6 +74,8 @@ namespace CommunityFinder.Views
                         ImagePath = GetImageForCategory(c.Name)
                     });
                 }
+
+                ShowTopVisitedCategories();
             }
             catch (Exception ex)
             {
@@ -120,9 +125,7 @@ namespace CommunityFinder.Views
             if (e.CurrentSelection?.FirstOrDefault() is ForumCategoryDisplay category)
             {
                 CategoriesCollection.SelectedItem = null;
-
-                var original = _allCategories.First(c => c.Id == category.Id);
-                await Navigation.PushAsync(new ForumCategoryDetailPage(original, _forumService, _authService));
+                await NavigateToCategory(category);
             }
         }
 
@@ -132,12 +135,36 @@ namespace CommunityFinder.Views
             {
                 await frame.ScaleTo(0.95, 80);
                 await frame.ScaleTo(1, 80);
+
+                if (frame.BindingContext is ForumCategoryDisplay categoryDisplay)
+                {
+                    await NavigateToCategory(categoryDisplay);
+                }
             }
         }
 
-        private async void OnSearchTextChanged(object sender, TextChangedEventArgs e)
+        private async Task NavigateToCategory(ForumCategoryDisplay categoryDisplay)
         {
-            if (string.IsNullOrWhiteSpace(e.NewTextValue))
+            var original = _allCategories.FirstOrDefault(c => c.Id == categoryDisplay.Id);
+            if (original != null)
+            {
+                await Navigation.PushAsync(new ForumCategoryDetailPage(original, _forumService, _authService));
+            }
+        }
+
+        private async void OnSearchButtonClicked(object sender, EventArgs e)
+        {
+            await ExecuteSearchAsync(SearchEntry.Text);
+        }
+
+        private async void OnSearchCompleted(object sender, EventArgs e)
+        {
+            await ExecuteSearchAsync(SearchEntry.Text);
+        }
+
+        private async Task ExecuteSearchAsync(string searchText)
+        {
+            if (string.IsNullOrWhiteSpace(searchText))
             {
                 await LoadCategoriesAsync();
                 return;
@@ -145,7 +172,7 @@ namespace CommunityFinder.Views
 
             try
             {
-                var results = await _forumService.SearchPostsAsync(e.NewTextValue);
+                var results = await _forumService.SearchPostsAsync(searchText.Trim());
 
                 if (results.Count == 0)
                 {
@@ -158,6 +185,60 @@ namespace CommunityFinder.Views
             catch (Exception ex)
             {
                 await DisplayAlert("Error", $"Search failed: {ex.Message}", "OK");
+            }
+        }
+
+        private void ShowTopVisitedCategories()
+        {
+            TopVisitedLayout.Children.Clear();
+            var counts = GetCategoryViewCounts();
+
+            var visited = _allCategories
+                .Where(c => counts.ContainsKey(c.Id))
+                .OrderByDescending(c => counts[c.Id])
+                .Take(3)
+                .ToList();
+
+            TopVisitedSection.IsVisible = visited.Any();
+            if (!visited.Any()) return;
+
+            foreach (var category in visited)
+            {
+                var chip = new Frame
+                {
+                    BackgroundColor = Color.FromArgb("#EEF4FF"),
+                    Padding = new Thickness(12, 8),
+                    CornerRadius = 14,
+                    HasShadow = false,
+                    BindingContext = _categories.First(c => c.Id == category.Id)
+                };
+
+                var label = new Label
+                {
+                    Text = category.Name,
+                    FontAttributes = FontAttributes.Bold,
+                    TextColor = Color.FromArgb("#2D4A82")
+                };
+
+                chip.Content = label;
+                var tap = new TapGestureRecognizer();
+                tap.Tapped += async (s, e) => await NavigateToCategory((ForumCategoryDisplay)chip.BindingContext);
+                chip.GestureRecognizers.Add(tap);
+                TopVisitedLayout.Children.Add(chip);
+            }
+        }
+
+        private Dictionary<Guid, int> GetCategoryViewCounts()
+        {
+            try
+            {
+                var json = Preferences.Get(CategoryViewKey, "{}");
+                var data = JsonSerializer.Deserialize<Dictionary<Guid, int>>(json);
+                return data ?? new Dictionary<Guid, int>();
+            }
+            catch
+            {
+                return new Dictionary<Guid, int>();
             }
         }
 

--- a/CommunityFinder/Views/ForumCategoryDetailPage.xaml.cs
+++ b/CommunityFinder/Views/ForumCategoryDetailPage.xaml.cs
@@ -1,6 +1,9 @@
 using CommunityFinder.Models;
 using CommunityFinder.Services;
+using Microsoft.Maui.Storage;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Text.Json;
 
 namespace CommunityFinder.Views
 {
@@ -12,6 +15,7 @@ namespace CommunityFinder.Views
         private ObservableCollection<ForumPost> _posts;
         private List<ForumPost> _allPosts;
         private string _selectedPostType = "All";
+        private const string CategoryViewKey = "ForumCategoryViews";
 
         public ForumCategoryDetailPage(ForumCategory category, ForumService forumService, AuthService authService)
         {
@@ -32,6 +36,7 @@ namespace CommunityFinder.Views
         protected override async void OnAppearing()
         {
             base.OnAppearing();
+            TrackCategoryVisit();
             await LoadDataAsync();
         }
 
@@ -39,6 +44,26 @@ namespace CommunityFinder.Views
         {
             await LoadAnnouncementAsync();
             await LoadPostsAsync();
+        }
+
+        private void TrackCategoryVisit()
+        {
+            try
+            {
+                var json = Preferences.Get(CategoryViewKey, "{}");
+                var data = JsonSerializer.Deserialize<Dictionary<Guid, int>>(json) ?? new();
+
+                if (data.ContainsKey(_category.Id))
+                    data[_category.Id]++;
+                else
+                    data[_category.Id] = 1;
+
+                Preferences.Set(CategoryViewKey, JsonSerializer.Serialize(data));
+            }
+            catch
+            {
+                // Ignore telemetry failures
+            }
         }
 
         private async Task LoadAnnouncementAsync()

--- a/CommunityFinder/Views/MyPostsPage.xaml.cs
+++ b/CommunityFinder/Views/MyPostsPage.xaml.cs
@@ -1,6 +1,8 @@
 using CommunityFinder.Models;
 using CommunityFinder.Services;
 using Microsoft.Maui.Controls;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace CommunityFinder.Views
 {
@@ -11,6 +13,7 @@ namespace CommunityFinder.Views
         private bool _showingMyPosts = true;
         private List<ForumPost> _myPosts;
         private List<ForumReply> _repliesToMe;
+        private List<ForumCategory> _categoriesCache;
 
         public MyPostsPage(ForumService forumService, AuthService authService)
         {
@@ -29,6 +32,7 @@ namespace CommunityFinder.Views
         {
             try
             {
+                _categoriesCache = await _forumService.GetAllCategoriesAsync();
                 _myPosts = await _forumService.GetUserPostsAsync();
                 _repliesToMe = await _forumService.GetRepliesToUserPostsAsync();
                 await ShowContentAnimated();
@@ -248,6 +252,8 @@ namespace CommunityFinder.Views
                 }
             };
 
+            var post = _myPosts?.FirstOrDefault(p => p.Id == reply.PostId);
+
             var usernameLabel = new Label
             {
                 Text = $"👤 {reply.Username}",
@@ -272,11 +278,22 @@ namespace CommunityFinder.Views
             Grid.SetColumn(reportButton, 1);
             grid.Add(reportButton);
 
+            var topicLabel = new Label
+            {
+                Text = post?.Topic ?? "View reply",
+                FontSize = 13,
+                TextColor = Colors.Gray,
+                Margin = new Thickness(0, 6, 0, 0)
+            };
+            Grid.SetRow(topicLabel, 1);
+            Grid.SetColumnSpan(topicLabel, 2);
+            grid.Add(topicLabel);
+
             var contentLabel = new Label
             {
                 Text = reply.Content,
                 FontSize = 14,
-                Margin = new Thickness(0, 10, 0, 0),
+                Margin = new Thickness(0, 28, 0, 0),
                 LineBreakMode = LineBreakMode.WordWrap
             };
             Grid.SetRow(contentLabel, 1);
@@ -287,7 +304,11 @@ namespace CommunityFinder.Views
             return frame;
         }
 
-        private string GetCategoryName(Guid categoryId) => "Category";
+        private string GetCategoryName(Guid categoryId)
+        {
+            var category = _categoriesCache?.FirstOrDefault(c => c.Id == categoryId);
+            return category?.Name ?? "Category";
+        }
 
         private async Task OnPostCardTapped(ForumPost post) =>
             await Navigation.PushAsync(new PostDetailPage(post, _forumService, _authService));


### PR DESCRIPTION
## Summary
- ensure replies to your posts surface the replier’s username reliably and show the related topic
- add a search button and recommended top-visited categories while fixing Android tap navigation into categories
- track category visits and cache category metadata for clearer My Posts and reply cards

## Testing
- dotnet build *(fails in container: dotnet CLI not available)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692165441f80833385fc689ebff49303)