### PR TITLE
Refactor HistoryPage to single scrolling CollectionView

### DIFF
--- a/CommunityFinder/Models/HistoryItem.cs
+++ b/CommunityFinder/Models/HistoryItem.cs
@@ -8,6 +8,7 @@ namespace CommunityFinder.Models
         public string DetailUrl { get; set; }
         public string ItemType { get; set; }  // "COURSE" or "EVENT"
         public bool IsEvent { get; set; }
+        public bool IsFavorite { get; set; }
 
         public static HistoryItem FromCourse(CourseItem course)
         {
@@ -18,7 +19,8 @@ namespace CommunityFinder.Models
                 Outlet = course.Outlet,
                 DetailUrl = course.DetailUrl,
                 ItemType = "COURSE",
-                IsEvent = false
+                IsEvent = false,
+                IsFavorite = false
             };
         }
 
@@ -31,7 +33,8 @@ namespace CommunityFinder.Models
                 Outlet = eventItem.Outlet,
                 DetailUrl = eventItem.DetailUrl,
                 ItemType = "EVENT",
-                IsEvent = true
+                IsEvent = true,
+                IsFavorite = false
             };
         }
     }

--- a/CommunityFinder/Views/HistoryPage.xaml
+++ b/CommunityFinder/Views/HistoryPage.xaml
@@ -6,219 +6,155 @@
              Title="History"
              BackgroundColor="#DEF685">
 
-    <ScrollView>
-        <StackLayout Padding="10">
+    <CollectionView ItemsSource="{Binding CombinedHistory}"
+                    SelectionMode="Single"
+                    SelectionChanged="OnHistoryItemTapped"
+                    IsGrouped="True"
+                    Margin="0"
+                    VerticalOptions="FillAndExpand">
+        <CollectionView.Header>
+            <StackLayout Padding="10" Spacing="0">
+                <!-- =============== 搜索区域 =============== -->
+                <Frame BackgroundColor="#CDE6F5"
+                       Padding="10"
+                       CornerRadius="8"
+                       HasShadow="True"
+                       Margin="0,10,0,20">
 
-            <!-- =============== 搜索区域 =============== -->
-            <Frame BackgroundColor="#CDE6F5"
-                   Padding="10"
-                   CornerRadius="8"
-                   HasShadow="True"
-                   Margin="0,10,0,20">
+                    <VerticalStackLayout Spacing="10">
 
-                <VerticalStackLayout Spacing="10">
+                        <!-- 搜索输入框 -->
+                        <Entry Placeholder="Search by title or outlet..."
+                               Text="{Binding SearchText}"
+                               TextChanged="OnSearchTextChanged"
+                               BackgroundColor="White"
+                               PlaceholderColor="Gray"
+                               FontSize="16"
+                               Margin="0,5" />
 
-                    <!-- 搜索输入框 -->
-                    <Entry Placeholder="Search by title or outlet..."
-                           Text="{Binding SearchText}"
-                           TextChanged="OnSearchTextChanged"
-                           BackgroundColor="White"
-                           PlaceholderColor="Gray"
-                           FontSize="16"
-                           Margin="0,5" />
+                        <!-- 分类筛选：范围与类型 -->
+                        <HorizontalStackLayout Spacing="10">
 
-                    <!-- 分类筛选：范围与类型 -->
-                    <HorizontalStackLayout Spacing="10">
+                            <!-- 搜索范围选择 -->
+                            <Picker x:Name="ScopePicker"
+                                    Title="Search Scope"
+                                    SelectedIndexChanged="OnScopeChanged">
+                                <Picker.Items>
+                                    <x:String>All</x:String>
+                                    <x:String>Browsing History</x:String>
+                                    <x:String>Favorite Courses</x:String>
+                                </Picker.Items>
+                            </Picker>
 
-                        <!-- 搜索范围选择 -->
-                        <Picker x:Name="ScopePicker"
-                                Title="Search Scope"
-                                SelectedIndexChanged="OnScopeChanged">
-                            <Picker.Items>
-                                <x:String>All</x:String>
-                                <x:String>Browsing History</x:String>
-                                <x:String>Favorite Courses</x:String>
-                            </Picker.Items>
-                        </Picker>
+                            <!-- 类型选择 -->
+                            <Picker x:Name="TypePicker"
+                                    Title="Item Type"
+                                    SelectedIndexChanged="OnTypeChanged">
+                                <Picker.Items>
+                                    <x:String>All</x:String>
+                                    <x:String>Course</x:String>
+                                    <x:String>Event</x:String>
+                                </Picker.Items>
+                            </Picker>
 
-                        <!-- 类型选择 -->
-                        <Picker x:Name="TypePicker"
-                                Title="Item Type"
-                                SelectedIndexChanged="OnTypeChanged">
-                            <Picker.Items>
-                                <x:String>All</x:String>
-                                <x:String>Course</x:String>
-                                <x:String>Event</x:String>
-                            </Picker.Items>
-                        </Picker>
+                        </HorizontalStackLayout>
+                    </VerticalStackLayout>
+                </Frame>
+            </StackLayout>
+        </CollectionView.Header>
 
-                    </HorizontalStackLayout>
-                </VerticalStackLayout>
-            </Frame>
+        <CollectionView.GroupHeaderTemplate>
+            <DataTemplate>
+                <Grid Padding="10" ColumnDefinitions="*,Auto" BackgroundColor="#FFFFFF">
+                    <Label Text="{Binding Title}"
+                           FontSize="24"
+                           HorizontalOptions="Start"
+                           VerticalOptions="Center" />
+                    <Button Grid.Column="1"
+                            Text="{Binding ClearButtonText}"
+                            BackgroundColor="#EF8687"
+                            TextColor="White"
+                            Margin="10,0,0,0"
+                            Command="{Binding ClearCommand}" />
+                </Grid>
+            </DataTemplate>
+        </CollectionView.GroupHeaderTemplate>
 
-            <!-- ====================== Browsing History ====================== -->
-            <Label Text="Browsing History"
-                   FontSize="24"
-                   HorizontalOptions="Center"
-                   Margin="0,10"/>
+        <CollectionView.ItemTemplate>
+            <DataTemplate>
+                <Frame Margin="10"
+                       Padding="10"
+                       HasShadow="True"
+                       CornerRadius="8">
+                    <Frame.Style>
+                        <Style TargetType="Frame">
+                            <Setter Property="BackgroundColor" Value="#D5B7B6"/>
+                            <Style.Triggers>
+                                <DataTrigger TargetType="Frame"
+                                             Binding="{Binding ItemType}"
+                                             Value="COURSE">
+                                    <Setter Property="BackgroundColor" Value="#A4C2F4"/>
+                                </DataTrigger>
+                                <DataTrigger TargetType="Frame"
+                                             Binding="{Binding ItemType}"
+                                             Value="EVENT">
+                                    <Setter Property="BackgroundColor" Value="#EAD1DC"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Frame.Style>
 
-            <Button Text="Clear All History"
-                    BackgroundColor="#EF8687"
-                    TextColor="White"
-                    Margin="10"
-                    Clicked="OnClearAllHistoryClicked"/>
+                    <StackLayout Orientation="Horizontal" VerticalOptions="Center">
+                        <StackLayout HorizontalOptions="StartAndExpand">
+                            <HorizontalStackLayout Spacing="8" Margin="0,0,0,4">
+                                <Label Text="{Binding ItemType}"
+                                       FontSize="10"
+                                       BackgroundColor="#FFA726"
+                                       TextColor="White"
+                                       Padding="4,2"
+                                       FontAttributes="Bold"/>
+                            </HorizontalStackLayout>
 
-            <CollectionView ItemsSource="{Binding FilteredBrowsingHistory}"
-                            SelectionMode="Single"
-                            SelectionChanged="OnHistoryItemTapped">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <Frame Margin="10"
-                               Padding="10"
-                               HasShadow="True"
-                               CornerRadius="8">
-                            <Frame.Style>
-                                <Style TargetType="Frame">
-                                    <Setter Property="BackgroundColor" Value="#D5B7B6"/>
+                            <Label Text="{Binding Title}"
+                                   FontSize="18"
+                                   FontAttributes="Bold"/>
+                            <Label Text="{Binding Outlet}"
+                                   FontSize="14"
+                                   TextColor="Gray"/>
+                        </StackLayout>
+
+                        <Button Text="Delete"
+                                BackgroundColor="#EF8687"
+                                TextColor="White"
+                                Padding="10,5"
+                                Command="{Binding BindingContext.DeleteHistoryCommand, Source={x:Reference ThisPage}}"
+                                CommandParameter="{Binding .}">
+                            <Button.Style>
+                                <Style TargetType="Button">
                                     <Style.Triggers>
-                                        <DataTrigger TargetType="Frame"
-                                                     Binding="{Binding ItemType}"
-                                                     Value="COURSE">
-                                            <Setter Property="BackgroundColor" Value="#A4C2F4"/>
-                                        </DataTrigger>
-                                        <DataTrigger TargetType="Frame"
-                                                     Binding="{Binding ItemType}"
-                                                     Value="EVENT">
-                                            <Setter Property="BackgroundColor" Value="#EAD1DC"/>
+                                        <DataTrigger TargetType="Button"
+                                                     Binding="{Binding IsFavorite}"
+                                                     Value="True">
+                                            <Setter Property="Command" Value="{Binding BindingContext.DeleteFavoriteCourseCommand, Source={x:Reference ThisPage}}" />
                                         </DataTrigger>
                                     </Style.Triggers>
                                 </Style>
-                            </Frame.Style>
-
-                            <StackLayout Orientation="Horizontal" VerticalOptions="Center">
-                                <StackLayout HorizontalOptions="StartAndExpand">
-                                    <HorizontalStackLayout Spacing="8" Margin="0,0,0,4">
-                                        <Label Text="{Binding ItemType}"
-                                               FontSize="10"
-                                               BackgroundColor="#FFA726"
-                                               TextColor="White"
-                                               Padding="4,2"
-                                               FontAttributes="Bold"/>
-                                    </HorizontalStackLayout>
-
-                                    <Label Text="{Binding Title}"
-                                           FontSize="18"
-                                           FontAttributes="Bold"/>
-                                    <Label Text="{Binding Outlet}"
-                                           FontSize="14"
-                                           TextColor="Gray"/>
-                                </StackLayout>
-
-                                <Button Text="Delete"
-                                        BackgroundColor="#EF8687"
-                                        TextColor="White"
-                                        Padding="10,5"
-                                        Command="{Binding BindingContext.DeleteHistoryCommand, Source={x:Reference ThisPage}}"
-                                        CommandParameter="{Binding .}"/>
-                                <Button Text="+"
-                                        WidthRequest="36"
-                                        HeightRequest="36"
-                                        CornerRadius="18"
-                                        BackgroundColor="#4A90E2"
-                                        TextColor="White"
-                                        FontSize="20"
-                                        Margin="8,0,0,0"
-                                        Clicked="OnSelectButtonClicked"
-                                        CommandParameter="{Binding .}"
-                                        IsVisible="{Binding Source={x:Reference ThisPage}, Path=IsSelectionMode}" />
-                            </StackLayout>
-                        </Frame>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-
-
-            <!-- ====================== Favorite Courses ====================== -->
-            <Label Text="Favorite Courses"
-                   FontSize="24"
-                   HorizontalOptions="Center"
-                   Margin="0,10"/>
-
-            <Button Text="Clear All Favorites"
-                    BackgroundColor="#EF8687"
-                    TextColor="White"
-                    Margin="10"
-                    Clicked="OnClearAllFavoritesClicked"/>
-
-            <CollectionView ItemsSource="{Binding FilteredFavoriteCourses}"
-                            SelectionMode="Single"
-                            SelectionChanged="OnFavoriteItemTapped">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <Frame Margin="10"
-                               Padding="10"
-                               HasShadow="True"
-                               CornerRadius="8">
-                            <Frame.Style>
-                                <Style TargetType="Frame">
-                                    <Setter Property="BackgroundColor" Value="#88ACBC"/>
-                                    <Style.Triggers>
-                                        <DataTrigger TargetType="Frame"
-                                                     Binding="{Binding ItemType}"
-                                                     Value="COURSE">
-                                            <Setter Property="BackgroundColor" Value="#A4C2F4"/>
-                                        </DataTrigger>
-                                        <DataTrigger TargetType="Frame"
-                                                     Binding="{Binding ItemType}"
-                                                     Value="EVENT">
-                                            <Setter Property="BackgroundColor" Value="#EAD1DC"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Frame.Style>
-
-                            <StackLayout Orientation="Horizontal" VerticalOptions="Center">
-                                <StackLayout HorizontalOptions="StartAndExpand">
-                                    <HorizontalStackLayout Spacing="8" Margin="0,0,0,4">
-                                        <Label Text="{Binding ItemType}"
-                                               FontSize="10"
-                                               BackgroundColor="#FFA726"
-                                               TextColor="White"
-                                               Padding="4,2"
-                                               FontAttributes="Bold"/>
-                                    </HorizontalStackLayout>
-
-                                    <Label Text="{Binding Title}"
-                                           FontSize="18"
-                                           FontAttributes="Bold"/>
-                                    <Label Text="{Binding Outlet}"
-                                           FontSize="14"
-                                           TextColor="Gray"/>
-                                </StackLayout>
-
-                                <Button Text="Delete"
-                                        BackgroundColor="#EF8687"
-                                        TextColor="White"
-                                        Padding="10,5"
-                                        Command="{Binding BindingContext.DeleteFavoriteCourseCommand, Source={x:Reference ThisPage}}"
-                                        CommandParameter="{Binding .}"/>
-                                <Button Text="+"
-                                        WidthRequest="36"
-                                        HeightRequest="36"
-                                        CornerRadius="18"
-                                        BackgroundColor="#4A90E2"
-                                        TextColor="White"
-                                        FontSize="20"
-                                        Margin="8,0,0,0"
-                                        Clicked="OnSelectButtonClicked"
-                                        CommandParameter="{Binding .}"
-                                        IsVisible="{Binding Source={x:Reference ThisPage}, Path=IsSelectionMode}" />
-                            </StackLayout>
-                        </Frame>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-
-        </StackLayout>
-    </ScrollView>
+                            </Button.Style>
+                        </Button>
+                        <Button Text="+"
+                                WidthRequest="36"
+                                HeightRequest="36"
+                                CornerRadius="18"
+                                BackgroundColor="#4A90E2"
+                                TextColor="White"
+                                FontSize="20"
+                                Margin="8,0,0,0"
+                                Clicked="OnSelectButtonClicked"
+                                CommandParameter="{Binding .}"
+                                IsVisible="{Binding Source={x:Reference ThisPage}, Path=IsSelectionMode}" />
+                    </StackLayout>
+                </Frame>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
 </ContentPage>

--- a/CommunityFinder/Views/HistoryPage.xaml.cs
+++ b/CommunityFinder/Views/HistoryPage.xaml.cs
@@ -1,10 +1,24 @@
-﻿using CommunityFinder.Models;
+using CommunityFinder.Models;
 using CommunityFinder.Services;
 using System.Collections.ObjectModel;
 using System.Windows.Input;
 
 namespace CommunityFinder.Views
 {
+    public class HistoryGroup : ObservableCollection<HistoryItem>
+    {
+        public string Title { get; }
+        public ICommand ClearCommand { get; }
+        public string ClearButtonText { get; }
+
+        public HistoryGroup(string title, string clearButtonText, ICommand clearCommand)
+        {
+            Title = title;
+            ClearButtonText = clearButtonText;
+            ClearCommand = clearCommand;
+        }
+    }
+
     public partial class HistoryPage : ContentPage
     {
         private readonly AuthService _authService;
@@ -16,6 +30,7 @@ namespace CommunityFinder.Views
         // Filtered display collections
         public ObservableCollection<HistoryItem> FilteredBrowsingHistory { get; } = new();
         public ObservableCollection<HistoryItem> FilteredFavoriteCourses { get; } = new();
+        public ObservableCollection<HistoryGroup> CombinedHistory { get; } = new();
 
         // Search-related properties
         public string SearchText { get; set; } = string.Empty;
@@ -53,6 +68,7 @@ namespace CommunityFinder.Views
             FilteredBrowsingHistory.Clear();
             foreach (var item in BrowsingHistory)
             {
+                item.IsFavorite = false;
                 if (MatchFilter(item))
                     FilteredBrowsingHistory.Add(item);
             }
@@ -61,9 +77,27 @@ namespace CommunityFinder.Views
             FilteredFavoriteCourses.Clear();
             foreach (var item in FavoriteCourses)
             {
+                item.IsFavorite = true;
                 if (MatchFilter(item))
                     FilteredFavoriteCourses.Add(item);
             }
+
+            RebuildGroupedItems();
+        }
+
+        private void RebuildGroupedItems()
+        {
+            CombinedHistory.Clear();
+
+            var browsingGroup = new HistoryGroup("Browsing History", "Clear All History", ClearAllHistoryCommand);
+            foreach (var item in FilteredBrowsingHistory)
+                browsingGroup.Add(item);
+            CombinedHistory.Add(browsingGroup);
+
+            var favoriteGroup = new HistoryGroup("Favorite Courses", "Clear All Favorites", ClearAllFavoritesCommand);
+            foreach (var item in FilteredFavoriteCourses)
+                favoriteGroup.Add(item);
+            CombinedHistory.Add(favoriteGroup);
         }
 
         private bool MatchFilter(HistoryItem item)
@@ -121,6 +155,7 @@ namespace CommunityFinder.Views
                 FavoriteCourses.Clear();
                 FilteredBrowsingHistory.Clear();
                 FilteredFavoriteCourses.Clear();
+                CombinedHistory.Clear();
 
                 var userGuid = Guid.Parse(_authService.Client.Auth.CurrentSession.User.Id);
 
@@ -153,7 +188,11 @@ namespace CommunityFinder.Views
                             .Where(x => x.ClassId == id)
                             .Single();
                         if (course != null)
-                            FavoriteCourses.Add(HistoryItem.FromCourse(course));
+                        {
+                            var favorite = HistoryItem.FromCourse(course);
+                            favorite.IsFavorite = true;
+                            FavoriteCourses.Add(favorite);
+                        }
                     }
                 }
 
@@ -184,7 +223,11 @@ namespace CommunityFinder.Views
                             .Where(x => x.EventId == id)
                             .Single();
                         if (ev != null)
-                            FavoriteCourses.Add(HistoryItem.FromEvent(ev));
+                        {
+                            var favorite = HistoryItem.FromEvent(ev);
+                            favorite.IsFavorite = true;
+                            FavoriteCourses.Add(favorite);
+                        }
                     }
                 }
 
@@ -218,7 +261,7 @@ namespace CommunityFinder.Views
             if (e.CurrentSelection?.FirstOrDefault() is HistoryItem item)
             {
                 if (sender is CollectionView cv) cv.SelectedItem = null;
-                
+
                 // If in selection mode, trigger the ItemSelected event and return
                 if (IsSelectionMode)
                 {
@@ -252,7 +295,7 @@ namespace CommunityFinder.Views
             if (e.CurrentSelection?.FirstOrDefault() is HistoryItem item)
             {
                 if (sender is CollectionView cv) cv.SelectedItem = null;
-                
+
                 // If in selection mode, trigger the ItemSelected event and return
                 if (IsSelectionMode)
                 {


### PR DESCRIPTION
## Summary
- replace HistoryPage layout with a single grouped CollectionView that owns scrolling
- move search and filtering controls into the CollectionView header and add group headers with clear actions
- support favorite identification and command routing through shared HistoryItem metadata

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69216914887083338380c62e1d0e72da)