### PR TITLE
Enhance forum category search and deletion rules

### DIFF
--- a/CommunityFinder/Services/ForumService.cs
+++ b/CommunityFinder/Services/ForumService.cs
@@ -100,7 +100,7 @@ namespace CommunityFinder.Services
         }
 
         // ========== Post Operations ==========
-        public async Task<List<ForumPost>> GetPostsByCategoryAsync(Guid categoryId, string postType = null)
+        public async Task<List<ForumPost>> GetPostsByCategoryAsync(Guid categoryId, string postType = null, string searchTerm = null)
         {
             var query = _client.From<ForumPost>()
                 .Where(x => x.CategoryId == categoryId);
@@ -113,7 +113,17 @@ namespace CommunityFinder.Services
             var response = await query
                 .Order(x => x.CreatedAt, Supabase.Postgrest.Constants.Ordering.Descending)
                 .Get();
-            return response.Models;
+
+            var posts = response.Models;
+
+            if (!string.IsNullOrWhiteSpace(searchTerm))
+            {
+                posts = posts
+                    .Where(p => p.Topic?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) == true)
+                    .ToList();
+            }
+
+            return posts;
         }
 
         public async Task<ForumPost> GetPostByIdAsync(Guid postId)
@@ -286,8 +296,18 @@ namespace CommunityFinder.Services
 
             if (reply == null) return false;
 
-            // Only allow deletion by reply owner or admin
-            if (reply.UserId != userId && !IsAdmin())
+            var post = await GetPostByIdAsync(reply.PostId);
+            var parentReply = reply.ParentReplyId.HasValue
+                ? await GetReplyByIdAsync(reply.ParentReplyId.Value)
+                : null;
+
+            // Allow deletion by reply owner, post owner, parent reply owner, or admin
+            var isReplyOwner = reply.UserId == userId;
+            var isPostOwner = post?.UserId == userId;
+            var isParentReplyOwner = parentReply?.UserId == userId;
+            var isAdmin = IsAdmin();
+
+            if (!isReplyOwner && !isPostOwner && !isParentReplyOwner && !isAdmin)
                 throw new UnauthorizedAccessException("You don't have permission to delete this reply");
 
             // Delete child replies if any (replies to this reply)

--- a/CommunityFinder/Views/ForumCategoryDetailPage.xaml
+++ b/CommunityFinder/Views/ForumCategoryDetailPage.xaml
@@ -5,7 +5,7 @@
              x:Name="ThisPage"
              BackgroundColor="#F9FFE3">
 
-    <Grid RowDefinitions="Auto,Auto,Auto,*,Auto">
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto,*,Auto">
         <!-- Category Name -->
         <Label Grid.Row="0" 
                x:Name="CategoryNameLabel"
@@ -43,10 +43,31 @@
             </VerticalStackLayout>
         </Frame>
 
+        <!-- Category Search -->
+        <Frame Grid.Row="2"
+               BackgroundColor="White"
+               Padding="12"
+               Margin="10,0,10,10"
+               CornerRadius="10"
+               HasShadow="True">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <Entry x:Name="CategorySearchEntry"
+                       Placeholder="Search posts in this category..."
+                       Completed="OnCategorySearchCompleted" />
+                <Button Text="Search"
+                        Grid.Column="1"
+                        BackgroundColor="#4A90E2"
+                        TextColor="White"
+                        Clicked="OnCategorySearchButtonClicked"
+                        CornerRadius="10"
+                        Padding="12,8" />
+            </Grid>
+        </Frame>
+
         <!-- Post Category Filter -->
-        <HorizontalStackLayout Grid.Row="2" Margin="10,0" Spacing="10">
+        <HorizontalStackLayout Grid.Row="3" Margin="10,0" Spacing="10">
             <Label Text="Post Category:" VerticalOptions="Center" FontAttributes="Bold"/>
-            <Picker x:Name="PostTypePicker" 
+            <Picker x:Name="PostTypePicker"
                     HorizontalOptions="FillAndExpand"
                     SelectedIndexChanged="OnPostTypeChanged">
                 <Picker.Items>
@@ -59,7 +80,7 @@
 
 
         <!-- Posts List -->
-        <ScrollView Grid.Row="3">
+        <ScrollView Grid.Row="4">
             <CollectionView x:Name="PostsCollection"
                             SelectionMode="Single"
                             SelectionChanged="OnPostSelected">
@@ -121,7 +142,7 @@
         </ScrollView>
 
         <!-- Add Post Button (Floating) -->
-        <Frame Grid.Row="4"
+        <Frame Grid.Row="5"
                BackgroundColor="#28A745"
                CornerRadius="30"
                WidthRequest="60"

--- a/CommunityFinder/Views/ForumCategoryDetailPage.xaml.cs
+++ b/CommunityFinder/Views/ForumCategoryDetailPage.xaml.cs
@@ -1,6 +1,7 @@
 using CommunityFinder.Models;
 using CommunityFinder.Services;
 using Microsoft.Maui.Storage;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text.Json;
@@ -15,6 +16,7 @@ namespace CommunityFinder.Views
         private ObservableCollection<ForumPost> _posts;
         private List<ForumPost> _allPosts;
         private string _selectedPostType = "All";
+        private string _searchTerm = string.Empty;
         private const string CategoryViewKey = "ForumCategoryViews";
 
         public ForumCategoryDetailPage(ForumCategory category, ForumService forumService, AuthService authService)
@@ -101,9 +103,16 @@ namespace CommunityFinder.Views
             }
             var filtered = _allPosts;
 
+            if (!string.IsNullOrWhiteSpace(_searchTerm))
+            {
+                filtered = filtered
+                    .Where(p => p.Topic?.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) == true)
+                    .ToList();
+            }
+
             if (_selectedPostType != "All")
             {
-                filtered = _allPosts.Where(p => p.PostType == _selectedPostType).ToList();
+                filtered = filtered.Where(p => p.PostType == _selectedPostType).ToList();
             }
 
             foreach (var post in filtered)
@@ -115,6 +124,18 @@ namespace CommunityFinder.Views
         private void OnPostTypeChanged(object sender, EventArgs e)
         {
             _selectedPostType = PostTypePicker.SelectedItem?.ToString() ?? "All";
+            ApplyFilter();
+        }
+
+        private void OnCategorySearchCompleted(object sender, EventArgs e)
+        {
+            _searchTerm = CategorySearchEntry.Text?.Trim() ?? string.Empty;
+            ApplyFilter();
+        }
+
+        private void OnCategorySearchButtonClicked(object sender, EventArgs e)
+        {
+            _searchTerm = CategorySearchEntry.Text?.Trim() ?? string.Empty;
             ApplyFilter();
         }
 

--- a/CommunityFinder/Views/PostDetailPage.xaml.cs
+++ b/CommunityFinder/Views/PostDetailPage.xaml.cs
@@ -2,7 +2,9 @@ using CommunityFinder.Models;
 using CommunityFinder.Services;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Platform;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Maui.Graphics;
 
 
@@ -19,6 +21,7 @@ namespace CommunityFinder.Views
         private string _linkedCourseId;
         private string _linkedEventId;
         private Dictionary<Guid, Frame> _replyFrames = new();
+        private Guid? _currentUserId => GetCurrentUserId();
 
         public PostDetailPage(ForumPost post, ForumService forumService, AuthService authService, Guid? targetReplyId = null)
         {
@@ -127,6 +130,7 @@ namespace CommunityFinder.Views
                     new RowDefinition { Height = GridLength.Auto },
                     new RowDefinition { Height = GridLength.Auto },
                     new RowDefinition { Height = GridLength.Auto },
+                    new RowDefinition { Height = GridLength.Auto },
                     new RowDefinition { Height = GridLength.Auto }
                 },
                 ColumnDefinitions =
@@ -185,6 +189,29 @@ namespace CommunityFinder.Views
                 Grid.SetRow(linkFrame, 3);
                 Grid.SetColumnSpan(linkFrame, 2);
                 grid.Add(linkFrame);
+            }
+
+            var actionStack = new HorizontalStackLayout { Spacing = 10 };
+
+            if (UserCanDeletePost())
+            {
+                var deleteButton = new Button
+                {
+                    Text = "Delete",
+                    BackgroundColor = Color.FromArgb("#6C757D"),
+                    TextColor = Colors.White,
+                    Padding = new Thickness(10, 5),
+                    FontSize = 12
+                };
+                deleteButton.Clicked += async (s, e) => await OnDeletePostClicked();
+                actionStack.Add(deleteButton);
+            }
+
+            if (actionStack.Children.Count > 0)
+            {
+                Grid.SetRow(actionStack, 4);
+                Grid.SetColumnSpan(actionStack, 2);
+                grid.Add(actionStack);
             }
 
             frame.Content = grid;
@@ -292,7 +319,7 @@ namespace CommunityFinder.Views
             reportButton.Clicked += async (s, e) => await OnReportReplyClicked(reply.Id);
             actionStack.Add(reportButton);
 
-            if (_forumService.IsAdmin())
+            if (UserCanDeleteReply(reply))
             {
                 var deleteButton = new Button
                 {
@@ -462,6 +489,63 @@ namespace CommunityFinder.Views
         {
             _linkedEventId = eventId;
             _linkedCourseId = null;
+        }
+
+        private Guid? GetCurrentUserId()
+        {
+            var userId = _authService.Client?.Auth?.CurrentSession?.User?.Id;
+            if (Guid.TryParse(userId, out var parsed))
+            {
+                return parsed;
+            }
+            return null;
+        }
+
+        private bool UserCanDeletePost()
+        {
+            var userId = _currentUserId;
+            if (!userId.HasValue) return false;
+
+            return _post.UserId == userId || _forumService.IsAdmin();
+        }
+
+        private bool UserCanDeleteReply(ForumReply reply)
+        {
+            var userId = _currentUserId;
+            if (!userId.HasValue) return false;
+
+            var isReplyOwner = reply.UserId == userId.Value;
+            var isPostOwner = _post.UserId == userId.Value;
+            var isAdmin = _forumService.IsAdmin();
+            var parentOwner = false;
+
+            if (reply.ParentReplyId.HasValue && _replies != null)
+            {
+                var parent = _replies.FirstOrDefault(r => r.Id == reply.ParentReplyId.Value);
+                if (parent != null)
+                {
+                    parentOwner = parent.UserId == userId.Value;
+                }
+            }
+
+            return isReplyOwner || isPostOwner || parentOwner || isAdmin;
+        }
+
+        private async Task OnDeletePostClicked()
+        {
+            var confirm = await DisplayAlert("Delete Post", "Are you sure you want to delete this post and all replies?", "Yes", "No");
+            if (!confirm) return;
+
+            try
+            {
+                await _forumService.DeletePostAsync(_post.Id);
+                await DisplayAlert("Success", "Post deleted", "OK");
+                await Navigation.PopAsync();
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert("Error", $"Failed to delete post: {ex.Message}", "OK");
+            }
         }
 
         private async Task OnReportReplyClicked(Guid replyId)


### PR DESCRIPTION
## Summary
- add a category-scoped search bar to filter posts by title directly within category detail
- update forum deletion rules to allow post owners, reply authors, parent reply authors, and admins to remove replies as required
- expose delete controls on post and reply cards so authorized users can remove posts and nested replies, cascading counts and UI updates

## Testing
- dotnet build (fails: dotnet not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69258ae047a48333b0b5db2f6d3359e0)