### PR TITLE
Enable admin category deletion and threaded forum replies

### DIFF
--- a/CommunityFinder/Services/ForumService.cs
+++ b/CommunityFinder/Services/ForumService.cs
@@ -76,6 +76,57 @@ namespace CommunityFinder.Services
             return category;
         }
 
+        public async Task DeleteCategoryAsync(Guid categoryId)
+        {
+            if (!IsAdmin()) throw new UnauthorizedAccessException("Only admins can delete categories");
+
+            var category = await _client.From<ForumCategory>()
+                .Where(x => x.Id == categoryId)
+                .Single();
+
+            if (category == null) return;
+
+            var postsResponse = await _client.From<ForumPost>()
+                .Where(x => x.CategoryId == categoryId)
+                .Get();
+            var posts = postsResponse.Models;
+
+            foreach (var post in posts)
+            {
+                var replies = await GetRepliesByPostIdAsync(post.Id);
+                if (replies != null && replies.Any())
+                {
+                    var replyIds = replies.Select(r => r.Id).ToList();
+                    foreach (var replyId in replyIds)
+                    {
+                        await _client.From<ForumReport>()
+                            .Where(x => x.ReplyId == replyId)
+                            .Delete();
+                    }
+
+                    await _client.From<ForumReply>()
+                        .Where(x => x.PostId == post.Id)
+                        .Delete();
+                }
+
+                await _client.From<ForumReport>()
+                    .Where(x => x.PostId == post.Id)
+                    .Delete();
+
+                await _client.From<ForumPost>()
+                    .Where(x => x.Id == post.Id)
+                    .Delete();
+            }
+
+            await _client.From<ForumAnnouncement>()
+                .Where(x => x.CategoryId == categoryId)
+                .Delete();
+
+            await _client.From<ForumCategory>()
+                .Where(x => x.Id == categoryId)
+                .Delete();
+        }
+
         // ========== Announcement Operations ==========
         public async Task<ForumAnnouncement> GetAnnouncementAsync(Guid categoryId)
         {

--- a/CommunityFinder/Views/AdminAlertsPage.xaml.cs
+++ b/CommunityFinder/Views/AdminAlertsPage.xaml.cs
@@ -181,7 +181,7 @@ namespace CommunityFinder.Views
                     var post = await _forumService.GetPostByIdAsync(report.PostId.Value);
                     if (post != null)
                     {
-                        await Navigation.PushAsync(new PostDetailPage(post, _forumService, _authService));
+                        await Navigation.PushAsync(new PostDetailPage(post, _forumService, _authService, highlightPost: true));
                     }
                 }
                 else if (report.ReplyId.HasValue)

--- a/CommunityFinder/Views/ForumCategoriesPage.xaml
+++ b/CommunityFinder/Views/ForumCategoriesPage.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CommunityFinder.Views.ForumCategoriesPage"
+             x:Name="PageRoot"
              Title="Forum"
              BackgroundColor="#F9FFE3">
 
@@ -85,13 +86,20 @@
                                            LineBreakMode="WordWrap" />
 
                                     <!-- 管理员专用：打开 Admin Alerts 页面 -->
-                                    <Button x:Name="ReportsButton"
-                                            Text="Reports"
-                                            IsVisible="False"          
+                                    <Button Text="Reports"
+                                            IsVisible="{Binding Source={x:Reference PageRoot}, Path=IsAdmin}"
                                             BackgroundColor="#DC3545"
                                             TextColor="White"
                                             Padding="10,6"
                                             Clicked="OnReportsClicked" />
+
+                                    <Button Text="Delete"
+                                            IsVisible="{Binding Source={x:Reference PageRoot}, Path=IsAdmin}"
+                                            BackgroundColor="#6C757D"
+                                            TextColor="White"
+                                            Padding="10,6"
+                                            Clicked="OnDeleteCategoryClicked"
+                                            CommandParameter="{Binding Id}" />
                                 </VerticalStackLayout>
                             </Frame>
                         </DataTemplate>

--- a/CommunityFinder/Views/ForumCategoriesPage.xaml.cs
+++ b/CommunityFinder/Views/ForumCategoriesPage.xaml.cs
@@ -16,6 +16,8 @@ namespace CommunityFinder.Views
         private List<ForumCategory> _allCategories;
         private const string CategoryViewKey = "ForumCategoryViews";
 
+        public bool IsAdmin => _forumService?.IsAdmin() == true;
+
         public ForumCategoriesPage(ForumService forumService, AuthService authService)
         {
             InitializeComponent();
@@ -263,6 +265,29 @@ namespace CommunityFinder.Views
             catch (Exception ex)
             {
                 await DisplayAlert("Error", $"Failed to create category: {ex.Message}", "OK");
+            }
+        }
+
+        private async void OnDeleteCategoryClicked(object sender, EventArgs e)
+        {
+            if (sender is Button button && button.CommandParameter is Guid categoryId)
+            {
+                var confirm = await DisplayAlert("Delete Category",
+                    "Deleting a category will remove all posts, replies, announcements, and reports under it. Continue?",
+                    "Yes", "No");
+
+                if (!confirm) return;
+
+                try
+                {
+                    await _forumService.DeleteCategoryAsync(categoryId);
+                    await DisplayAlert("Success", "Category deleted", "OK");
+                    await LoadCategoriesAsync();
+                }
+                catch (Exception ex)
+                {
+                    await DisplayAlert("Error", $"Failed to delete category: {ex.Message}", "OK");
+                }
             }
         }
     }

--- a/CommunityFinder/Views/PostDetailPage.xaml.cs
+++ b/CommunityFinder/Views/PostDetailPage.xaml.cs
@@ -17,20 +17,23 @@ namespace CommunityFinder.Views
         private readonly AuthService _authService;
         private List<ForumReply> _replies;
         private readonly Guid? _targetReplyId;
+        private readonly bool _highlightPost;
         private Guid? _replyingToId = null;
         private string _linkedCourseId;
         private string _linkedEventId;
         private Dictionary<Guid, Frame> _replyFrames = new();
+        private Frame _mainPostFrame;
         private Guid? _currentUserId => _forumService.GetCurrentUserId();
 
 
-        public PostDetailPage(ForumPost post, ForumService forumService, AuthService authService, Guid? targetReplyId = null)
+        public PostDetailPage(ForumPost post, ForumService forumService, AuthService authService, Guid? targetReplyId = null, bool highlightPost = false)
         {
             InitializeComponent();
             _post = post;
             _forumService = forumService;
             _authService = authService;
             _targetReplyId = targetReplyId;
+            _highlightPost = highlightPost;
         }
 
         protected override async void OnAppearing()
@@ -50,6 +53,7 @@ namespace CommunityFinder.Views
             var mainPostFrame = CreatePostCard(_post);
             mainPostFrame.Opacity = 0;
             mainPostFrame.Scale = 0.8;
+            _mainPostFrame = mainPostFrame;
             PostContainer.Add(mainPostFrame);
             cards.Add(mainPostFrame);
 
@@ -58,25 +62,7 @@ namespace CommunityFinder.Views
             {
                 _replies = await _forumService.GetRepliesByPostIdAsync(_post.Id);
 
-                foreach (var reply in _replies.Where(r => r.ParentReplyId == null))
-                {
-                    var replyFrame = CreateReplyCard(reply, isMainReply: true);
-                    replyFrame.Opacity = 0;
-                    replyFrame.Scale = 0.8;
-                    PostContainer.Add(replyFrame);
-                    cards.Add(replyFrame);
-                    _replyFrames[reply.Id] = replyFrame;
-
-                    foreach (var subReply in _replies.Where(r => r.ParentReplyId == reply.Id))
-                    {
-                        var subReplyFrame = CreateReplyCard(subReply, isMainReply: false, parentUsername: reply.Username);
-                        subReplyFrame.Opacity = 0;
-                        subReplyFrame.Scale = 0.8;
-                        PostContainer.Add(subReplyFrame);
-                        cards.Add(subReplyFrame);
-                        _replyFrames[subReply.Id] = subReplyFrame;
-                    }
-                }
+                AddRepliesRecursive(parentId: null, level: 0, cards);
             }
             catch (Exception ex)
             {
@@ -96,11 +82,19 @@ namespace CommunityFinder.Views
                 delay = 100; // 每张卡片间隔 100ms
             }
 
-            await ScrollToTargetReplyAsync();
+            await ApplyHighlightsAsync();
         }
 
-        private async Task ScrollToTargetReplyAsync()
+        private async Task ApplyHighlightsAsync()
         {
+            if (_highlightPost && _mainPostFrame != null)
+            {
+                _mainPostFrame.BorderColor = Color.FromArgb("#FFC107");
+                _mainPostFrame.BackgroundColor = Color.FromArgb("#FFF8E1");
+                await Task.Delay(150);
+                await MainScrollView.ScrollToAsync(_mainPostFrame, ScrollToPosition.Start, true);
+            }
+
             if (!_targetReplyId.HasValue) return;
 
             if (_replyFrames.TryGetValue(_targetReplyId.Value, out var frame))
@@ -249,14 +243,36 @@ namespace CommunityFinder.Views
             }
         }
 
+        private void AddRepliesRecursive(Guid? parentId, int level, List<VisualElement> cards, string parentUsername = null)
+        {
+            if (_replies == null) return;
+
+            var children = _replies
+                .Where(r => r.ParentReplyId == parentId)
+                .OrderBy(r => r.CreatedAt)
+                .ToList();
+
+            foreach (var reply in children)
+            {
+                var replyFrame = CreateReplyCard(reply, level, parentUsername);
+                replyFrame.Opacity = 0;
+                replyFrame.Scale = 0.8;
+                PostContainer.Add(replyFrame);
+                cards.Add(replyFrame);
+                _replyFrames[reply.Id] = replyFrame;
+
+                AddRepliesRecursive(reply.Id, level + 1, cards, reply.Username);
+            }
+        }
+
         // --------------------- 创建回复卡片 ---------------------
-        private Frame CreateReplyCard(ForumReply reply, bool isMainReply, string parentUsername = null)
+        private Frame CreateReplyCard(ForumReply reply, int level, string parentUsername = null)
         {
             var frame = new Frame
             {
-                BackgroundColor = isMainReply ? Color.FromArgb("#F9F9F9") : Color.FromArgb("#EFEFEF"),
+                BackgroundColor = level == 0 ? Color.FromArgb("#F9F9F9") : Color.FromArgb("#EFEFEF"),
                 Padding = 15,
-                Margin = new Thickness(isMainReply ? 0 : 20, 0, 0, 10),
+                Margin = new Thickness(Math.Min(level * 20, 80), 0, 0, 10),
                 CornerRadius = 8,
                 HasShadow = false,
                 BorderColor = Colors.LightGray
@@ -279,7 +295,7 @@ namespace CommunityFinder.Views
             };
 
             var usernameText = $"👤 {reply.Username}";
-            if (!isMainReply && !string.IsNullOrEmpty(parentUsername))
+            if (level > 0 && !string.IsNullOrEmpty(parentUsername))
             {
                 usernameText = $"👤 {reply.Username} → {parentUsername}";
             }
@@ -325,19 +341,17 @@ namespace CommunityFinder.Views
             }
 
             var actionStack = new HorizontalStackLayout { Spacing = 10 };
-            if (isMainReply)
+
+            var replyButton = new Button
             {
-                var replyButton = new Button
-                {
-                    Text = "Reply",
-                    BackgroundColor = Color.FromArgb("#4A90E2"),
-                    TextColor = Colors.White,
-                    Padding = new Thickness(10, 5),
-                    FontSize = 12
-                };
-                replyButton.Clicked += (s, e) => OnReplyToFloorClicked(reply.Id);
-                actionStack.Add(replyButton);
-            }
+                Text = "Reply",
+                BackgroundColor = Color.FromArgb("#4A90E2"),
+                TextColor = Colors.White,
+                Padding = new Thickness(10, 5),
+                FontSize = 12
+            };
+            replyButton.Clicked += (s, e) => OnReplyToFloorClicked(reply.Id, reply.Username);
+            actionStack.Add(replyButton);
 
             var reportButton = new Button
             {
@@ -420,10 +434,12 @@ namespace CommunityFinder.Views
             }
         }
 
-        private void OnReplyToFloorClicked(Guid replyId)
+        private void OnReplyToFloorClicked(Guid replyId, string username)
         {
             _replyingToId = replyId;
-            ReplyEntry.Placeholder = "Replying to a comment...";
+            ReplyEntry.Placeholder = string.IsNullOrEmpty(username)
+                ? "Replying to a comment..."
+                : $"Replying to {username}...";
             ReplyEntry.Focus();
         }
 


### PR DESCRIPTION
## Summary
- allow admins to delete categories, removing related content and reports
- highlight posts when opened from post reports for clarity
- support nested reply chains with consistent styling and reply targeting

## Testing
- Not run (environment missing `dotnet` CLI)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c8127d6083339deb82b3e072073b)